### PR TITLE
Add .iml files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 .idea
+*.iml
 ### Eclipse ###
 .apt_generated
 .classpath


### PR DESCRIPTION
We should not add .iml files to Git. They are not needed for other team members and can cause conflicts when merging changes.
I have added "*.iml" in the .gitignore file.